### PR TITLE
feature/QMUN-1299

### DIFF
--- a/QMContactListService/QMContactListService/QMContactListService.m
+++ b/QMContactListService/QMContactListService/QMContactListService.m
@@ -125,8 +125,10 @@
     [self retrieveUsersWithIDs:[self.contactListMemoryStorage userIDsFromContactList]
 				 forceDownload:NO completion:^(QBResponse *responce, QBGeneralResponsePage *page, NSArray *users)
      {
-         if ([weakSelf.multicastDelegate respondsToSelector:@selector(contactListService:contactListDidChange:)]) {
-             [weakSelf.multicastDelegate contactListService:self contactListDidChange:contactList];
+         if (users.count > 0) {
+             if ([weakSelf.multicastDelegate respondsToSelector:@selector(contactListService:contactListDidChange:)]) {
+                 [weakSelf.multicastDelegate contactListService:self contactListDidChange:contactList];
+             }
          }
      }];
 }

--- a/QMContactListService/QMContactListService/QMContactListService.m
+++ b/QMContactListService/QMContactListService/QMContactListService.m
@@ -125,11 +125,8 @@
     [self retrieveUsersWithIDs:[self.contactListMemoryStorage userIDsFromContactList]
 				 forceDownload:NO completion:^(QBResponse *responce, QBGeneralResponsePage *page, NSArray *users)
      {
-         if (responce.success) {
-             
-             if ([weakSelf.multicastDelegate respondsToSelector:@selector(contactListService:contactListDidChange:)]) {
-                 [weakSelf.multicastDelegate contactListService:self contactListDidChange:contactList];
-             }
+         if ([weakSelf.multicastDelegate respondsToSelector:@selector(contactListService:contactListDidChange:)]) {
+             [weakSelf.multicastDelegate contactListService:self contactListDidChange:contactList];
          }
      }];
 }


### PR DESCRIPTION
contactListDidChange will now correctly call multicast delegate even when there is no need to download user from server.

Description: QBResponse instance was always nil when local user contact item updated.
