### PR TITLE
Small fix: Control reaches end of non-void function

### DIFF
--- a/QMUsersService/QMUsersService/QMUsersService.m
+++ b/QMUsersService/QMUsersService/QMUsersService.m
@@ -551,8 +551,8 @@
 
 - (BFTask *)searchUsersWithPhoneNumbers:(NSArray *)phoneNumbers {
     
-    [self searchUsersWithPhoneNumbers:phoneNumbers
-                                 page:[QBGeneralResponsePage responsePageWithCurrentPage:1 perPage:100]];
+    return [self searchUsersWithPhoneNumbers:phoneNumbers
+										page:[QBGeneralResponsePage responsePageWithCurrentPage:1 perPage:100]];
 }
 
 - (BFTask *)searchUsersWithPhoneNumbers:(NSArray *)phoneNumbers page:(QBGeneralResponsePage *)page {


### PR DESCRIPTION
**Made/Proposed changes:**
- Made searchUsersWithPhoneNumbers: in QMUsersService.m line 554 to return desired BFTask

**How should this be manually tested?**
No need to test

**Does the documentation need an update?**
No

**Reason:**
QMServices/QMUsersService/QMUsersService/QMUsersService.m:556:1:
Control reaches end of non-void function

“searchUsersWithPhoneNumbers” has to return BFTask
