### PR TITLE
bugix/services_message_cache_update_pr_dev

### DIFF
--- a/QMChatService/QMChatService/QMChatService.m
+++ b/QMChatService/QMChatService/QMChatService.m
@@ -1430,13 +1430,21 @@ static NSString* const kQMChatServiceDomain = @"com.q-municate.chatservice";
                                didUpdateChatDialogInMemoryStorage:chatDialogToUpdate];
                     }
                 }
-                
+				
                 // updating message in memory storage
                 [strongSelf.messagesMemoryStorage updateMessage:message];
-                
+				
+				// update message in cache
+				if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didUpdateMessage:forDialogID:)]) {
+					
+					[strongSelf.multicastDelegate chatService:strongSelf
+											 didUpdateMessage:message
+												  forDialogID:chatDialogToUpdate.ID];
+				}
+				
                 [updatedMessages addObject:message];
             }
-            
+			
             [strongSelf.messagesToRead removeObject:message.ID];
             
             dispatch_group_leave(readGroup);


### PR DESCRIPTION
When sending a read status via `readMessages:forDialogID:completion:`, we noticed that the read status was correctly updated in the message memory store but as soon as the app was relaunched, the previously updated read status had disappeared again. We do use caching in our app and after a little bit of investigation we found out that `readMessages:forDialogID:completion:` does update the affected dialog in cache and the message in memory store. What it doesn't to, though, is to update the message in cache, which leads to the changes being undone once the app is relaunched.
We therefore added a call to `chatService:didUpdateMessage:forDialogID:` on the `multicastDelegate` in order to trigger an update of the respective message in cache.

**Made/Proposed changes:**
- Call `chatService:didUpdateMessage:forDialogID:` in `readMessages:forDialogID:completion:` in order to make sure messages in cache get updated as well
