### PR TITLE
`QMChatService.loadCachedDialogsWithCompletion:_` loading wrong dialogues fix

### DIFF
--- a/QMChatService/QMChatService/QMChatService.h
+++ b/QMChatService/QMChatService/QMChatService.h
@@ -192,7 +192,7 @@ typedef void(^QMCacheCollection)(NSArray * _Nullable collection);
                 completion:(nullable void(^)(QBResponse *response))completion;
 
 /**
- *  Loads dialogs specific to user from disc cache and puth them in memory storage.
+ *  Loads dialogs specific to user from disc cache and puts them in memory storage.
  *  @warning This method MUST be called after the login.
  *
  *  @param completion Completion block to handle ending of operation.


### PR DESCRIPTION
Added filtering out dialogues that do not belong to currently logged in user.

**Made/Proposed changes:**

- Added filtering loaded dialogues in `QMChatService.loadCachedDialogsWithCompletion:_` method.
- Fixed typo in doc comment to the method.

**How should this be manually tested?**

Call `QMChatService.loadCachedDialogsWithCompletion:_` on device with cached dialogues for different users. It should load only those dialogues that belong to currently logged in user.

**Does the documentation need an update?**

No.